### PR TITLE
always calculate total energy and virial for LAMMPS

### DIFF
--- a/interface/lammps/USER-NEP/pair_NEP.cpp
+++ b/interface/lammps/USER-NEP/pair_NEP.cpp
@@ -94,7 +94,8 @@ void PairNEP::init_style()
   neighbor->requests[irequest]->full = 1;
 #endif
 
-  nep_model.init_from_file(model_filename);
+  bool is_rank_0 = (comm->me == 0);
+  nep_model.init_from_file(model_filename, is_rank_0);
   inited = true;
   cutoff = nep_model.paramb.rc_radial;
   cutoffsq = cutoff * cutoff;

--- a/interface/lammps/USER-NEP/pair_NEP.cpp
+++ b/interface/lammps/USER-NEP/pair_NEP.cpp
@@ -108,24 +108,30 @@ double PairNEP::init_one(int i, int j) { return cutoff; }
 
 void PairNEP::compute(int eflag, int vflag)
 {
-  if (eflag || vflag)
+  if (eflag || vflag) {
     ev_setup(eflag, vflag);
-  else
-    evflag = vflag_fdotr = eflag_global = eflag_atom = 0;
-  double energy = 0;
-  double* p_site_en = NULL;
-  double** p_site_virial = NULL;
-  if (eflag_atom)
-    p_site_en = eatom;
-  if (vflag_atom)
-    p_site_virial = cvatom;
-  nep_model.compute_for_lammps(
-    list->inum, list->ilist, list->numneigh, list->firstneigh, atom->type, atom->x, energy,
-    p_site_en, atom->f, p_site_virial);
-  if (eflag_global) {
-    eng_vdwl = energy;
   }
-  if (vflag_fdotr) {
-    virial_fdotr_compute();
+  double total_potential = 0.0;
+  double total_virial[6] = {0.0};
+  double* per_atom_potential = nullptr;
+  double** per_atom_virial = nullptr;
+  if (eflag_atom) {
+    per_atom_potential = eatom;
+  }
+  if (cvflag_atom) {
+    per_atom_virial = cvatom;
+  }
+
+  nep_model.compute_for_lammps(
+    list->inum, list->ilist, list->numneigh, list->firstneigh, atom->type, atom->x, total_potential,
+    total_virial, per_atom_potential, atom->f, per_atom_virial);
+
+  if (eflag) {
+    eng_vdwl += total_potential;
+  }
+  if (vflag) {
+    for (int component = 0; component < 6; ++component) {
+      virial[component] += total_virial[component];
+    }
   }
 }

--- a/interface/lammps/USER-NEP/pair_NEP.cpp
+++ b/interface/lammps/USER-NEP/pair_NEP.cpp
@@ -37,6 +37,12 @@ using namespace LAMMPS_NS;
 
 PairNEP::PairNEP(LAMMPS* lmp) : Pair(lmp)
 {
+#if LAMMPS_VERSION_NUMBER >= 20201130
+  centroidstressflag = CENTROID_AVAIL;
+#else
+  centroidstressflag = 2;
+#endif
+
   restartinfo = 0;
   manybody_flag = 1;
 

--- a/src/nep.h
+++ b/src/nep.h
@@ -60,7 +60,7 @@ public:
   NEP3();
   NEP3(const std::string& potential_filename);
 
-  void init_from_file(const std::string& potential_filename);
+  void init_from_file(const std::string& potential_filename, const bool is_rank_0);
 
   // type[num_atoms] should be integers 0, 1, ..., mapping to the atom types in nep.txt in order
   // box[9] is ordered as ax, bx, cx, ay, by, cy, az, bz, cz

--- a/src/nep.h
+++ b/src/nep.h
@@ -99,8 +99,9 @@ public:
     int** firstneigh,        // list->firstneigh
     int* type,               // atom->type
     double** x,              // atom->x
-    double& total_potential, // eng_vdwl
-    double* potential,       // &eatom[0] or nullptr
+    double& total_potential, // total potential energy for the current processor
+    double total_virial[6],  // total virial for the current processor
+    double* potential,       // eatom or nullptr
     double** f,              // atom->f
     double** virial          // cvatom or nullptr
   );


### PR DESCRIPTION
* Seems we need to alwasys calculate the total energy and virial (6 components only) for LAMMPS.
* The per-atom energy and virial are still only calculated as requested.
* I have only tested that the other parts are not affected. I have not tested the LAMMPS part, which is left for the users.
* I am not sure if I have made the sign and order of the virial components correct. The users will tell.
* Solve the problem of reporting NEP-related info multiple times from multiple threads.