### PR TITLE
add the hybrid pair_style for lammps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
   
 ## Use the NEP-LAMMPS interface
 
-* `atom_style` can only be `atomic`
+* `atom_style` can be `atomic` and `full`
 * `units` must be `metal`
 * Specify the `pair_style` in the following way:
   ```shell
@@ -60,8 +60,14 @@
   
 * Some atom types can be missing in the simulated system. For example you can use the above NEP model to simulate a CuNi binary alloy. It is important to make sure to still set Cu atoms to type 2 and Ni atoms to type 3. In this case, atom types 1 and 4 are missing.
 
-* One can hybrid NEP with other potentials in LAMMPS.
-  
+* One can hybrid NEP with other potentials in LAMMPS, for example `lj/cut`
+  ```shell
+  pair_style hybrid lj/cut 1.0 nep YOUR_NEP_MODEL_FILE.txt  
+  pair_coeff 1*4 1*4 nep YOUR_NEP_MODEL_FILE.txt
+  pair_coeff 1*5 5 lj/cut 1.0 1.0
+  ```
+  This will set the interaction of elements of type 1-5 and elements of type 5 to lj/cut, as well as `lj/cut/coul/long`.
+
 * If you want to calculate the heat current correctly, use the following command to get the 9-component per-atom virial:
   ```shell
   compute 1 all centroid/stress/atom NULL

--- a/interface/lammps/USER-NEP/pair_NEP.cpp
+++ b/interface/lammps/USER-NEP/pair_NEP.cpp
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <vector>
 
-#define LAMMPS_VERSION_NUMBER 20240417 // use the new neighbor list starting from this version
+#define LAMMPS_VERSION_NUMBER 20220324 // use the new neighbor list starting from this version
 
 using namespace LAMMPS_NS;
 
@@ -113,6 +113,7 @@ void PairNEP::init_style()
 }
 
 double PairNEP::init_one(int i, int j) { return cutoff; }
+
 void PairNEP::compute(int eflag, int vflag)
 {
   if (eflag || vflag) {
@@ -122,9 +123,6 @@ void PairNEP::compute(int eflag, int vflag)
   double total_virial[6] = {0.0};
   double* per_atom_potential = nullptr;
   double** per_atom_virial = nullptr;
-
-
-
   if (eflag_atom) {
     per_atom_potential = eatom;
   }

--- a/interface/lammps/USER-NEP/pair_NEP.cpp
+++ b/interface/lammps/USER-NEP/pair_NEP.cpp
@@ -31,7 +31,7 @@
 #include <string.h>
 #include <vector>
 
-#define LAMMPS_VERSION_NUMBER 20220324 // use the new neighbor list starting from this version
+#define LAMMPS_VERSION_NUMBER 20240417 // use the new neighbor list starting from this version
 
 using namespace LAMMPS_NS;
 
@@ -113,7 +113,6 @@ void PairNEP::init_style()
 }
 
 double PairNEP::init_one(int i, int j) { return cutoff; }
-
 void PairNEP::compute(int eflag, int vflag)
 {
   if (eflag || vflag) {
@@ -123,6 +122,9 @@ void PairNEP::compute(int eflag, int vflag)
   double total_virial[6] = {0.0};
   double* per_atom_potential = nullptr;
   double** per_atom_virial = nullptr;
+
+
+
   if (eflag_atom) {
     per_atom_potential = eatom;
   }
@@ -131,7 +133,7 @@ void PairNEP::compute(int eflag, int vflag)
   }
 
   nep_model.compute_for_lammps(
-    list->inum, list->ilist, list->numneigh, list->firstneigh, atom->type, atom->x, total_potential,
+   atom->nlocal, list->inum, list->ilist, list->numneigh, list->firstneigh, atom->type, atom->x, total_potential,
     total_virial, per_atom_potential, atom->f, per_atom_virial);
 
   if (eflag) {

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1815,7 +1815,7 @@ void find_force_radial_for_lammps(
             c_index += t1 * paramb.num_types + t2;
             gnp12 += fnp12[k] * annmb.c[c_index];
           }
-          double tmp12 = g_Fp[n1 + n * nlocal] * gnp12 * d12inv; ////luowh
+          double tmp12 = g_Fp[n1 + n * nlocal] * gnp12 * d12inv;
           for (int d = 0; d < 3; ++d) {
             f12[d] += tmp12 * r12[d];
           }

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1748,7 +1748,7 @@ void find_force_radial_for_lammps(
   int** g_NL,
   int* g_type,
   double** g_pos,
-  double* g_Fp, 
+  double* g_Fp,
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
   const double* g_gnp_radial,
 #endif

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1596,7 +1596,7 @@ void find_descriptor_for_lammps(
   double* g_sum_fxyz,
   double& g_total_potential,
   double* g_potential)
-{ 
+{
   for (int ii = 0; ii < N; ++ii) {
     int n1 = g_ilist[ii];
     int t1 = g_type[n1] - 1; // from LAMMPS to NEP convention

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1591,14 +1591,16 @@ void find_descriptor_for_lammps(
   const double* g_gn_radial,
   const double* g_gn_angular,
 #endif
-  double* g_Fp,
-  double* g_sum_fxyz,
+  double** g_Fp_lmp,
+  double** g_sum_fxyz_lmp,
   double& g_total_potential,
   double* g_potential)
-{
+{ 
+
   for (int ii = 0; ii < N; ++ii) {
     int n1 = g_ilist[ii];
-    int t1 = g_type[n1] - 1; // from LAMMPS to NEP convention
+    int t1 = g_type[n1] - 1;
+    // from LAMMPS to NEP convention
     double q[MAX_DIM] = {0.0};
 
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
@@ -1713,7 +1715,7 @@ void find_descriptor_for_lammps(
         find_q_with_5body(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       }
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
-        g_sum_fxyz[(n * NUM_OF_ABC + abc) * N + n1] = s[abc];
+        g_sum_fxyz_lmp[(n * NUM_OF_ABC + abc)][n1] = s[abc];///////luowh
       }
     }
 
@@ -1732,7 +1734,7 @@ void find_descriptor_for_lammps(
     }
 
     for (int d = 0; d < annmb.dim; ++d) {
-      g_Fp[d * N + n1] = Fp[d] * paramb.q_scaler[d];
+      g_Fp_lmp[d][n1] = Fp[d] * paramb.q_scaler[d];
     }
   }
 }
@@ -1746,7 +1748,7 @@ void find_force_radial_for_lammps(
   int** g_NL,
   int* g_type,
   double** g_pos,
-  double* g_Fp,
+  double** g_Fp_lmp, ///////luowh
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
   const double* g_gnp_radial,
 #endif
@@ -1782,7 +1784,7 @@ void find_force_radial_for_lammps(
             weight_left +
           g_gnp_radial[(index_right * paramb.num_types_sq + t12) * (paramb.n_max_radial + 1) + n] *
             weight_right;
-        double tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
+        double tmp12 = g_Fp_lmp[n][n1] * gnp12 * d12inv;
         for (int d = 0; d < 3; ++d) {
           f12[d] += tmp12 * r12[d];
         }
@@ -1795,7 +1797,7 @@ void find_force_radial_for_lammps(
       if (paramb.version == 2) {
         find_fn_and_fnp(paramb.n_max_radial, paramb.rcinv_radial, d12, fc12, fcp12, fn12, fnp12);
         for (int n = 0; n <= paramb.n_max_radial; ++n) {
-          double tmp12 = g_Fp[n1 + n * N] * fnp12[n] * d12inv;
+          double tmp12 = g_Fp_lmp[n][n1] * fnp12[n] * d12inv;
           tmp12 *= (paramb.num_types == 1)
                      ? 1.0
                      : annmb.c[(n * paramb.num_types + t1) * paramb.num_types + t2];
@@ -1813,7 +1815,7 @@ void find_force_radial_for_lammps(
             c_index += t1 * paramb.num_types + t2;
             gnp12 += fnp12[k] * annmb.c[c_index];
           }
-          double tmp12 = g_Fp[n1 + n * N] * gnp12 * d12inv;
+          double tmp12 = g_Fp_lmp[n][n1] * gnp12 * d12inv; ////luowh
           for (int d = 0; d < 3; ++d) {
             f12[d] += tmp12 * r12[d];
           }
@@ -1859,8 +1861,8 @@ void find_force_angular_for_lammps(
   int** g_NL,
   int* g_type,
   double** g_pos,
-  double* g_Fp,
-  double* g_sum_fxyz,
+  double** g_Fp_lmp,
+  double** g_sum_fxyz_lmp,
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
   const double* g_gn_angular,
   const double* g_gnp_angular,
@@ -1874,10 +1876,11 @@ void find_force_angular_for_lammps(
     double Fp[MAX_DIM_ANGULAR] = {0.0};
     double sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
-      Fp[d] = g_Fp[(paramb.n_max_radial + 1 + d) * N + n1];
+      Fp[d] = g_Fp_lmp[paramb.n_max_radial+1+d][n1];
+      double a =g_Fp_lmp[paramb.n_max_radial+1+d][n1];
     }
     for (int d = 0; d < (paramb.n_max_angular + 1) * NUM_OF_ABC; ++d) {
-      sum_fxyz[d] = g_sum_fxyz[d * N + n1];
+      sum_fxyz[d] = g_sum_fxyz_lmp[d][n1];
     }
 
     int t1 = g_type[n1] - 1; // from LAMMPS to NEP convention
@@ -3242,6 +3245,7 @@ void NEP3::find_polarizability(
 }
 
 void NEP3::compute_for_lammps(
+  int nlocal,
   int N,
   int* ilist,
   int* NN,
@@ -3255,28 +3259,47 @@ void NEP3::compute_for_lammps(
   double** virial)
 {
   if (num_atoms < N) {
-    Fp.resize(N * annmb.dim);
-    sum_fxyz.resize(N * (paramb.n_max_angular + 1) * NUM_OF_ABC);
     num_atoms = N;
   }
+  Fp_lmp = new double*[annmb.dim];
+    for (int i =0; i < annmb.dim; ++i){
+       Fp_lmp[i]=new double[nlocal];
+    }
+
+    sum_fxyz_lmp = new double*[(paramb.n_max_angular + 1) * NUM_OF_ABC];
+    for (int i =0; i <(paramb.n_max_angular + 1) * NUM_OF_ABC ; ++i){
+       sum_fxyz_lmp[i] = new double [nlocal];///the max of system
+    }
   find_descriptor_for_lammps(
     paramb, annmb, N, ilist, NN, NL, type, pos,
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
     gn_radial.data(), gn_angular.data(),
 #endif
-    Fp.data(), sum_fxyz.data(), total_potential, potential);
+    Fp_lmp, sum_fxyz_lmp, total_potential, potential);
   find_force_radial_for_lammps(
-    paramb, annmb, N, ilist, NN, NL, type, pos, Fp.data(),
+    paramb, annmb, N, ilist, NN, NL, type, pos, Fp_lmp,
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
     gnp_radial.data(),
 #endif
     force, total_virial, virial);
   find_force_angular_for_lammps(
-    paramb, annmb, N, ilist, NN, NL, type, pos, Fp.data(), sum_fxyz.data(),
+    paramb, annmb, N, ilist, NN, NL, type, pos, Fp_lmp, sum_fxyz_lmp,
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
     gn_angular.data(), gnp_angular.data(),
 #endif
     force, total_virial, virial);
+  
+  //delete the memory
+  for (int i =0; i < annmb.dim; ++i){
+       delete[] Fp_lmp[i];
+    }
+  delete[] Fp_lmp;
+  for (int i =0; i <(paramb.n_max_angular + 1) * NUM_OF_ABC ; ++i){
+       delete[] sum_fxyz_lmp[i] ;
+    }
+  delete[] sum_fxyz_lmp;
+
+  
   if (zbl.enabled) {
     find_force_ZBL_for_lammps(
       zbl, N, ilist, NN, NL, type, pos, force, total_virial, virial, total_potential, potential);

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1597,7 +1597,6 @@ void find_descriptor_for_lammps(
   double& g_total_potential,
   double* g_potential)
 { 
-
   for (int ii = 0; ii < N; ++ii) {
     int n1 = g_ilist[ii];
     int t1 = g_type[n1] - 1; // from LAMMPS to NEP convention
@@ -1715,7 +1714,7 @@ void find_descriptor_for_lammps(
         find_q_with_5body(paramb.n_max_angular + 1, n, s, q + (paramb.n_max_radial + 1));
       }
       for (int abc = 0; abc < NUM_OF_ABC; ++abc) {
-        g_sum_fxyz[(n * NUM_OF_ABC + abc) * nlocal + n1] = s[abc];///////luowh
+        g_sum_fxyz[(n * NUM_OF_ABC + abc) * nlocal + n1] = s[abc];
       }
     }
 
@@ -1749,7 +1748,7 @@ void find_force_radial_for_lammps(
   int** g_NL,
   int* g_type,
   double** g_pos,
-  double* g_Fp, ///////luowh
+  double* g_Fp, 
 #ifdef USE_TABLE_FOR_RADIAL_FUNCTIONS
   const double* g_gnp_radial,
 #endif

--- a/src/nep.cpp
+++ b/src/nep.cpp
@@ -1599,8 +1599,7 @@ void find_descriptor_for_lammps(
 
   for (int ii = 0; ii < N; ++ii) {
     int n1 = g_ilist[ii];
-    int t1 = g_type[n1] - 1;
-    // from LAMMPS to NEP convention
+    int t1 = g_type[n1] - 1; // from LAMMPS to NEP convention
     double q[MAX_DIM] = {0.0};
 
     for (int i1 = 0; i1 < g_NN[n1]; ++i1) {
@@ -1877,7 +1876,6 @@ void find_force_angular_for_lammps(
     double sum_fxyz[NUM_OF_ABC * MAX_NUM_N];
     for (int d = 0; d < paramb.dim_angular; ++d) {
       Fp[d] = g_Fp_lmp[paramb.n_max_radial+1+d][n1];
-      double a =g_Fp_lmp[paramb.n_max_radial+1+d][n1];
     }
     for (int d = 0; d < (paramb.n_max_angular + 1) * NUM_OF_ABC; ++d) {
       sum_fxyz[d] = g_sum_fxyz_lmp[d][n1];

--- a/src/nep.h
+++ b/src/nep.h
@@ -153,7 +153,7 @@ public:
   );
 
   void compute_for_lammps(
-    int nlocal,             //list->nlocal
+    int nlocal,              //list->nlocal
     int inum,                // list->inum
     int* ilist,              // list->ilist
     int* numneigh,           // list->numneigh

--- a/src/nep.h
+++ b/src/nep.h
@@ -178,8 +178,6 @@ public:
   std::vector<double> r12;
   std::vector<double> Fp;
   std::vector<double> sum_fxyz;
-  double** Fp_lmp;
-  double** sum_fxyz_lmp;
   std::vector<double> parameters;
   std::vector<std::string> element_list;
   void update_potential(double* parameters, ANN& ann);

--- a/src/nep.h
+++ b/src/nep.h
@@ -153,7 +153,7 @@ public:
   );
 
   void compute_for_lammps(
-    int nlocal,              //list->nlocal
+    int nlocal,              // list->nlocal
     int inum,                // list->inum
     int* ilist,              // list->ilist
     int* numneigh,           // list->numneigh

--- a/src/nep.h
+++ b/src/nep.h
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-// #define USE_TABLE_FOR_RADIAL_FUNCTIONS
+//#define USE_TABLE_FOR_RADIAL_FUNCTIONS
 
 class NEP3
 {
@@ -153,6 +153,7 @@ public:
   );
 
   void compute_for_lammps(
+    int nlocal,             //list->nlocal
     int inum,                // list->inum
     int* ilist,              // list->ilist
     int* numneigh,           // list->numneigh
@@ -177,6 +178,8 @@ public:
   std::vector<double> r12;
   std::vector<double> Fp;
   std::vector<double> sum_fxyz;
+  double** Fp_lmp;
+  double** sum_fxyz_lmp;
   std::vector<double> parameters;
   std::vector<std::string> element_list;
   void update_potential(double* parameters, ANN& ann);

--- a/src/nep.h
+++ b/src/nep.h
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-//#define USE_TABLE_FOR_RADIAL_FUNCTIONS
+// #define USE_TABLE_FOR_RADIAL_FUNCTIONS
 
 class NEP3
 {


### PR DESCRIPTION
Make the following changes:
Added variables `Fp_lmp` and `sum_fxyz_lmp` and `nlocal` to enable correct mapping for the lammps `hybrid pair_style`.