### PR TITLE
add a reminder for compiling LAMMPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   * `install.sh`
   
 * Step 2: Now you can copy the `USER-NEP/` folder into `YOUR_LAMMPS_PATH/src/` and start to compile LAMMPS in your favorite way. Good luck!
-  * Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
+Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
   
 ## Use the NEP-LAMMPS interface
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
   * `install.sh`
   
 * Step 2: Now you can copy the `USER-NEP/` folder into `YOUR_LAMMPS_PATH/src/` and start to compile LAMMPS in your favorite way. Good luck!
+
 Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
   
 ## Use the NEP-LAMMPS interface

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
   
 * Step 2: Now you can copy the `USER-NEP/` folder into `YOUR_LAMMPS_PATH/src/` and start to compile LAMMPS in your favorite way. Good luck!
 
-Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
+  Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
   
 ## Use the NEP-LAMMPS interface
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@
   * `install.sh`
   
 * Step 2: Now you can copy the `USER-NEP/` folder into `YOUR_LAMMPS_PATH/src/` and start to compile LAMMPS in your favorite way. Good luck!
+  Reminder: If you are compiling LAMMPS using `make`, ensure that you include the NEP package before the final compilation step:
+  ```bash
+make yes-NEP
+ For cmake, please add "PKG_NEP=on" with additional -D flags.
   
 ## Use the NEP-LAMMPS interface
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@
   * `install.sh`
   
 * Step 2: Now you can copy the `USER-NEP/` folder into `YOUR_LAMMPS_PATH/src/` and start to compile LAMMPS in your favorite way. Good luck!
-  Reminder: If you are compiling LAMMPS using `make`, ensure that you include the NEP package before the final compilation step:
-  ```bash
-make yes-NEP
- For cmake, please add "PKG_NEP=on" with additional -D flags.
+  * Reminder: If you are compiling LAMMPS using `make`, ensure that you run "make yes-NEP" before the final compilation. For cmake, please add "PKG_NEP=on" to enable NEP, along with your other -D flags during the configuration step.
   
 ## Use the NEP-LAMMPS interface
 


### PR DESCRIPTION
A reminder has been added to ensure users do not forget to enable the NEP package before the final LAMMPS compilation.